### PR TITLE
preliminary GUI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ module.exports = {
 
 ### From Node-RED Editor
 
-work in progress.
-<!-- 
 - clone this repository
 ```
  % git clone https://github.com/node-red/nrlint.git
@@ -79,10 +77,21 @@ work in progress.
 ```
 ...
     nrlint: {
-        rules: {
-            "no-func-name": "warn",
-            "func-style-eslint": { semi: 2 }
+      rules: [
+        {
+          "name": "no-func-name",
+          "mode": "warn",
+        },
+        {
+          "name": "func-style-eslint",
+          "parserOptions": {
+            "ecmaVersion": 6
+          },
+          "rules": {
+            "semi": 2
+          }
         }
+      ]
     }
 ...
 ```
@@ -90,10 +99,10 @@ work in progress.
 ```
  % npm start
 ```
-...then, lint tab (marked with paw) will be appeared.
--->
+- Then, lint tab (marked with a paw) will be appeared.
 
 ## Limitation
 - Only following rule can use from editor:
   - no-func-name
   - func-style-eslint
+  - flowsize

--- a/nr/nrlint.html
+++ b/nr/nrlint.html
@@ -12,6 +12,28 @@
 
         var FlowSet = function() {
             this.rn = RED.nodes;
+            var flows = [];
+            var configs = [];
+            var subflows = [];
+            var links = [];
+            RED.nodes.eachWorkspace(function(ws) {
+                var f = new FMFlow(ws.id, ws.name);
+                f.nodes = RED.nodes.filterNodes({z:ws.id});
+                flows.push(f);
+            });
+            RED.nodes.eachConfig(function(cn) {
+                configs.push(cn);
+            });
+            RED.nodes.eachSubflow(function(sf) {
+                subflows.push(sf);
+            });
+            RED.nodes.eachLink(function(ln) {
+                links.push(ln);
+            });
+            this.flows = flows;
+            this.configs = configs;
+            this.subflows = subflows;
+            this.links = links;
         };
 
         FlowSet.prototype.getAllNodesArray = function () {
@@ -160,8 +182,15 @@
             return null;
         }
 
+        var FMFlow = function(id, name) {
+            this.id = id;
+            this.name = name || "";
+            this.nodes = [];
+        };
+
         return {
             FlowSet: FlowSet,
+            FMFlow: FMFlow,
         };
     })();
 </script>
@@ -197,10 +226,17 @@
     })();
 
     function displayResult(result) {
+        var warnCount = 0;
+        var errCount = 0;
+        var table = $('<table class="lint-message red-ui-info-table"></table>').appendTo(lcontent);
+        var tableBody = $('<tbody>').appendTo(table);
+
         for (var i = 0; i < result.length; i++) {
             resid = result[i].ids[0];
+            if (result[i].severity === "warn") { warnCount++; }
+            if (result[i].severity === "error") { errCount++; }
             var metaRow = $('<div class="lint-message red-ui-debug-msg-meta"></div>').appendTo(lcontent);
-            $('<span class="red-ui-debug-msg-date">' + (new Date()).toLocaleString() + '</span>').appendTo(metaRow);
+            //$('<span class="red-ui-debug-msg-date">' + (new Date()).toLocaleString() + '</span>').appendTo(metaRow);
             $('<a>', { href: "#", class: "red-ui-debug-msg-name" }).text('node: ' + resid).appendTo(metaRow)
                 .on("click", function (closureItem) { 
                     return function(evt) {
@@ -208,19 +244,19 @@
                         RED.view.reveal(closureItem);
                     }
                 }(resid));
-            var el = $('<span class="lint-message red-ui-debug-msg-payload"></span>').appendTo(lcontent);
-            var debugMessage = RED.utils.createObjectElement(result[i].message, {
-                sourceId: result[i].ids[0]
-            });
-            debugMessage.appendTo(el);
+            var el = $('<span class="lint-message"></span>').appendTo(lcontent);
+            $('<div></div>').text(result[i].message).appendTo(el);
         }
+
+        $('<tr class="red-ui-help-info-row"><td>Warn</td><td align="right">'+warnCount+'</td></tr>').appendTo(tableBody);
+        $('<tr class="red-ui-help-info-row"><td>Error</td><td align="right">'+errCount+'</td></tr>').appendTo(tableBody);
     }
 
     function doLint() {
         var config = RED.settings.nrlint;
         var afs = new XRED.flowmanip.FlowSet();  // create sim for node objects
         var result = [];
-        if (config.rules) {
+        if (config.rules && Array.isArray(config.rules)) {
             var cxt = {};
             config.rules.forEach(function(r) {
                 var pname = XRED.util.normalisePluginName(r.name);
@@ -271,4 +307,36 @@
         $(".lint-message").remove();
     });
 
+</script>
+
+<script type="text/javascript">
+        var nrlintFlowsize = {
+            check: function (afs, conf, cxt) {
+                var flows = afs.flows;
+                var result = [];
+
+                flows.forEach(function (flow) {
+                    var nodes = flow.nodes;
+                    var maxSize = 100;
+
+                    if (conf.hasOwnProperty("maxSize")) {
+                        maxSize = conf.maxSize;
+                    }
+
+                    if (nodes.length > maxSize) {
+                        result.push({
+                            rule: "flowsize",
+                            ids: [flow.id],
+                            name: "flowsize",
+                            severity: "warn",
+                            message: "too large flow size"
+                        });
+                    }
+                });
+                return {
+                    context: cxt,
+                    result: result
+                };
+            }
+        };
 </script>


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR enables an Editor-integrated linter function so that flow developer can validate their code on the fly.  

### remaining issues
- some rules in browser-side (flowsize) are manually copied from CLI version, and other rules (func-style-eslint, no-func-name) are automatically generated using Webpack.  I also plan to use Babel for transpile a modern Node.js code to a code which is compatible with old browsers (IE11, etc.).  Use of complex tool lowers the developer's burden (code duplication, browser compatibility issue, etc.), but it also brings complicated build process and larger dependency of other packages.  We are still investigating how to write/generate browser-size code. 
- http-in-resp and loop rules are not yet ported to Editor-side.   
- Some GUI parts (CSS classes, etc.) are borrowed from other part of Node-RED Editor.  We should use our own CSS classes. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
