### PR TITLE
Improve no-loop detection

### DIFF
--- a/lib/rules/no-loops.js
+++ b/lib/rules/no-loops.js
@@ -13,13 +13,38 @@ module.exports = {
     create: function(context, ruleConfig) {
 
         let checked = {};
+        let stack = {};
+
         let followLinkNodes = false;
         if (ruleConfig.hasOwnProperty('followLinkNodes')) {
             followLinkNodes = ruleConfig.followLinkNodes;
         }
 
-        function checkNode(node) {
+        function checkNodeGraph(node) {
+            let result = new Set();
+            if (stack[node.id]) {
+                result.add(node.id);
+                return result;
+            }
+            if (checked[node.id]) {
+                return result;
+            }
+
             checked[node.id] = true;
+            stack[node.id] = true;
+            let next = node.getNextNodes(followLinkNodes);
+            for (let i=0; i<next.length; i++) {
+                let nextResult = checkNodeGraph(next[i]);
+                nextResult.forEach(result.add,result);
+            }
+            if (result.size > 0) {
+                result.add(node.id);
+            }
+            delete stack[node.id];
+            return result;
+        }
+
+        function checkNode(node) {
             if (node.getPreviousNodes(followLinkNodes).length === 0) {
                 // Nothing before this node - cannot be in a loop
                 return;
@@ -29,29 +54,15 @@ module.exports = {
                 // Nothing after this node - cannot be in a loop
                 return;
             }
-            let level = 1;
-            let stack = [node]
-            let visited = {};
-            while(stack.length > 0) {
-                let n = stack.pop();
-                checked[n.id] = true;
-                if (!visited[n.id]) {
-                    visited[n.id] = level++;
-                    let next = n.getNextNodes(followLinkNodes);
-                    next.forEach(nn => {
-                        if (!visited[nn.id]) {
-                            stack.push(nn);
-                        }
-                        else if (visited[nn.id] <=
-                                 visited[n.id]) {
-                            context.report({
-                                location: [n.id],
-                                message: "loop detected"
-                            });
-                        }
-                    });
-                }
+
+            const result = checkNodeGraph(node);
+            if (result.size > 0) {
+                context.report({
+                    location: Array.from(result),
+                    message: "loop detected"
+                });
             }
+
         }
         return {
             node: function(node) {


### PR DESCRIPTION
Fixes #12

This changes the algorithm used to detect loops to avoid the false-positives
identified in issue #12.

A side-effect is we now get a list of all nodes involved in the loop so
they can all be reported in one go.
