### PR TITLE
Fix function-eslint rule for precise linting

### DIFF
--- a/lib/rules/function-eslint/function-eslint.js
+++ b/lib/rules/function-eslint/function-eslint.js
@@ -5,11 +5,67 @@ var defaultConfig = {
     "env": {
         "es2021": true
     },
-    "extends": "eslint:recommended",
     "parserOptions": {
         "ecmaVersion": 12
     },
     "rules": {
+        "constructor-super": "error",
+        "for-direction": "error",
+        "getter-return": "error",
+        "no-async-promise-executor": "error",
+        "no-case-declarations": "error",
+        "no-class-assign": "error",
+        "no-compare-neg-zero": "error",
+        "no-cond-assign": "error",
+        "no-const-assign": "error",
+        "no-constant-condition": "error",
+        "no-control-regex": "error",
+        "no-debugger": "error",
+        "no-delete-var": "error",
+        "no-dupe-args": "error",
+        "no-dupe-class-members": "error",
+        "no-dupe-else-if": "error",
+        "no-dupe-keys": "error",
+        "no-duplicate-case": "error",
+        "no-empty": "error",
+        "no-empty-character-class": "error",
+        "no-empty-pattern": "error",
+        "no-ex-assign": "error",
+        "no-extra-boolean-cast": "error",
+        "no-extra-semi": "error",
+        "no-fallthrough": "error",
+        "no-func-assign": "error",
+        "no-global-assign": "error",
+        "no-import-assign": "error",
+        "no-inner-declarations": "error",
+        "no-invalid-regexp": "error",
+        "no-irregular-whitespace": "error",
+        "no-misleading-character-class": "error",
+        "no-mixed-spaces-and-tabs": "error",
+        "no-new-symbol": "error",
+        "no-obj-calls": "error",
+        "no-octal": "error",
+        "no-prototype-builtins": "error",
+        "no-redeclare": "error",
+        "no-regex-spaces": "error",
+        "no-self-assign": "error",
+        "no-setter-return": "error",
+        "no-shadow-restricted-names": "error",
+        "no-sparse-arrays": "error",
+        "no-this-before-super": "error",
+        "no-undef": "error",
+        "no-unexpected-multiline": "error",
+        "no-unreachable": "error",
+        "no-unsafe-finally": "error",
+        "no-unsafe-negation": "error",
+        "no-unused-labels": "error",
+        "no-unused-vars": "error",
+        "no-useless-catch": "error",
+        "no-useless-escape": "error",
+        "no-with": "error",
+        "require-yield": "error",
+        "use-isnan": "error",
+        "valid-typeof": "error"
     }
 }
 
@@ -31,7 +87,11 @@ module.exports = {
         return {
             "type:function": function(node) {
                 // TODO: lint the on-start / on-close code
-                var code = "function dummy(msg) {\n" + node.config.func + "\n};";
+                var code = "(async function(msg,__send__,__done__){"+
+                    "var __msgid__;"+
+                    "var node; // eslint-disable-line\n"+
+                    node.config.func+"\n"+
+                    "}); // eslint-disable-line";
                 var result = linter.verify(code, config);
                 result.forEach(function(r) {
                     // console.log(r);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
- The configuration generated by `nrlint --init` contains `"extends": "eslint:recommended"`. However, [this value is not interpreted by ESLint's linter.verify()](https://eslint.org/docs/developer-guide/nodejs-api#linterverify).  This fix expand the setting of the rule corresponding to `eslint:recommended` as the value of `rules`.
- To ensure correct linting of undefined variables etc., function and variable definitions have been included in the string surrounding the code, and comments have been added to prevent these lines from being linted.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
