### PR TITLE
Support --version option

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -5,13 +5,25 @@ const linter = require('../linter');
 
 const rules = {};
 
+function getVersion() {
+    let version = require(path.join(__dirname,"..","..","package.json")).version;
+    try {
+        fs.statSync(path.join(__dirname,"..","..",".git"));
+        version += "-git";
+    } catch (err) {
+        // No git directory
+    }
+    return version;
+}
+
 function parseArguments(args) {
     const knownOpts = {
         'help': Boolean,
         'config': [path],
         'format': String,
         'debug': Boolean,
-        'init': Boolean
+        'init': Boolean,
+        'version': Boolean
     };
 
     const shortHands = {
@@ -23,7 +35,7 @@ function parseArguments(args) {
 }
 
 function help() {
-    const helpMessage = `Lint tool for Node-RED flows
+    const helpMessage = `Lint tool for Node-RED flows (v${getVersion()})
     Usage: nrlint [-h] [-c configfile] flows.json
 
     Options:
@@ -32,6 +44,7 @@ function help() {
       -f, --format outputFormat    Output format: 'default,json'
       --debug                      Output debugging information
       --init                       Generate a default configuration
+      --version                    Output version information and exit
 `;
     console.log(helpMessage);
     return 0;
@@ -90,6 +103,11 @@ async function run(args) {
     }
     if (options.init) {
         return initialise();
+    }
+
+    if (options.version) {
+        console.log(getVersion());
+        return 0;
     }
 
     if (options.argv.remain.length !== 1) {


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

(Fixes #23)
Support `--version` option.

```
% node bin/nrlint.js
Error: no input file
Lint tool for Node-RED flows (v1.0.2-git)
    Usage: nrlint [-h] [-c configfile] flows.json

    Options:
      -h, --help                   Show this help
      -c, --config configfile      Configuration file to use, otherwise use .nrlintrc.js
      -f, --format outputFormat    Output format: 'default,json'
      --debug                      Output debugging information
      --init                       Generate a default configuration
      --version                    Output version information and exit

% node bin/nrlint.js --version
1.0.2-git

```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
