### PR TITLE
Add allowDefaultName options to function/link rules

### DIFF
--- a/lib/rules/no-loops.js
+++ b/lib/rules/no-loops.js
@@ -7,7 +7,11 @@ module.exports = {
             description: "ensure there are no loops in the flows"
         },
         options: {
-            followLinkNodes: { type: 'boolean', default: false}
+            followLinkNodes: {
+                type: 'boolean',
+                default: false,
+                label: 'follow link nodes'
+            }
         }
     },
     create: function(context, ruleConfig) {

--- a/lib/rules/no-unnamed-functions.js
+++ b/lib/rules/no-unnamed-functions.js
@@ -5,15 +5,32 @@ module.exports = {
         docs: {
             description: "ensure all Function nodes have a name"
         },
-        options: {}
+        options: {
+            allowDefaultNames: {
+                type: 'boolean',
+                default: true,
+                label: 'allow default names'
+            }
+        }
     },
     create: function(context, ruleConfig) {
+
+        let allowDefaultNames = true;
+        if (ruleConfig.hasOwnProperty('allowDefaultNames')) {
+            allowDefaultNames = ruleConfig.allowDefaultNames;
+        }
+
         return {
             "type:function": function(node) {
                 if (!node.config.name) {
                     context.report({
                         location: [node.id],
                         message: "Function node has no name"
+                    })
+                } else if (!allowDefaultNames && /^function \d+$/.test(node.config.name)) {
+                    context.report({
+                        location: [node.id],
+                        message: "Function node has default name"
                     })
                 }
             }

--- a/lib/rules/no-unnamed-links.js
+++ b/lib/rules/no-unnamed-links.js
@@ -5,15 +5,33 @@ module.exports = {
         docs: {
             description: "ensure all Links nodes have a name"
         },
-        options: {}
+        options: {
+            allowDefaultNames: {
+                type: 'boolean',
+                default: true,
+                label: 'allow default names'
+            }
+        }
     },
     create: function(context, ruleConfig) {
+
+        let allowDefaultNames = true;
+        if (ruleConfig.hasOwnProperty('allowDefaultNames')) {
+            allowDefaultNames = ruleConfig.allowDefaultNames;
+        }
+
         function checkNode(node) {
             if (!node.config.name) {
                 context.report({
                     location: [node.id],
                     message: "Link node has no name"
                 })
+            }
+            if (!allowDefaultNames && /^link (in|out) \d+$/.test(node.config.name)) {
+                context.report({
+                    location: [node.id],
+                    message: "Link node has default name"
+                })                
             }
         }
         return {

--- a/src/nrlint-core.html
+++ b/src/nrlint-core.html
@@ -247,9 +247,14 @@
                         var optProperties = item.meta.options[opt];
                         var optRow = $('<div class="red-ui-nrlint-rule-opt"></div>').appendTo(optionList);
                         var inputID = "red-ui-nrlint-rule--"+item.name+"-opt-"+i;
-                        var label = $('<label></label>',{for:inputID}).text(opt).appendTo(optRow);
+                        var label = $('<label></label>',{for:inputID}).text(optProperties.label || opt).appendTo(optRow);
                         if (optProperties.type === 'boolean') {
-                            var checkbox = $('<input type="checkbox">',{id:inputID}).prependTo(optRow);
+                            var checkbox = $('<input type="checkbox" id="'+inputID+'">').prependTo(optRow);
+                            if (item.config && item.config[opt] !== undefined) {
+                                checkbox.prop('checked', !!item.config[opt])
+                            } else {
+                                checkbox.prop('checked', !!optProperties.default)
+                            }
                             item.meta.options[opt].input = checkbox;
                             item.ui.options[opt].val = function() {
                                 return checkbox.prop("checked");


### PR DESCRIPTION
Adds `allowDefaultName` option to Function and Link node rules - defaults to `true`.

If set to `false`, then any Function or Link node with a default name (`function 1` `link in 28`) will get flagged.
