### PR TITLE
Replace eslint4b with eslint-linter-browserify

### DIFF
--- a/lib/rules/function-eslint/function-eslint.js
+++ b/lib/rules/function-eslint/function-eslint.js
@@ -1,9 +1,10 @@
-var Linter = require('eslint4b');
-var linter = new Linter();
+const { Linter } = require('eslint-linter-browserify');
+const linter = new Linter();
 
-var defaultConfig = {
+const defaultConfig = {
     "env": {
-        "es2021": true
+        "browser": true,
+        "es2022": true
     },
     "parserOptions": {
         "ecmaVersion": 12
@@ -70,7 +71,7 @@ var defaultConfig = {
 }
 
 function lintCode(config, property) {
-    var code = "const RED = {}; // eslint-disable-line\n"+
+    const code = "const RED = {}; // eslint-disable-line\n"+
         "const context = {}; // eslint-disable-line\n"+
         "const global = {}; // eslint-disable-line\n"+
         "const flow = {}; // eslint-disable-line\n"+
@@ -107,7 +108,7 @@ module.exports = {
         }
     },
     create: function(context, ruleConfig) {
-        var config = ruleConfig.config || defaultConfig;
+        const config = ruleConfig.config || defaultConfig;
         return {
             "type:function": function(node) {
                 reportResults(context,node,lintCode(config,node.config.func),"msg");

--- a/package.json
+++ b/package.json
@@ -45,9 +45,8 @@
         "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@eslint/eslintrc": "^0.4.2",
         "@node-red/flow-parser": "^1.0.2",
-        "eslint4b": "7.32.0",
+        "eslint-linter-browserify": "^8.39.0",
         "nopt": "^6.0.0",
         "table": "^6.8.0"
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack')
 
 module.exports = [{
     entry: path.resolve(__dirname, 'src/nrlint-worker.js'),
@@ -33,11 +34,17 @@ module.exports = [{
     },
     resolve: {
         fallback: {
-            "assert": path.resolve(__dirname, 'lib/rules/function-eslint/empty.js'),
-            "util":   false,
-            "path":   false
+            "window": false
         }
     },
     mode: 'production',
-    target: ['webworker']
+    target: ['webworker'],
+    plugins: [
+        new webpack.BannerPlugin({
+            raw: true,
+            entryOnly: true,
+            banner:
+              'let window;',
+          })
+    ]
 }];


### PR DESCRIPTION
Given the known issues with eslint4b (#38 #36 ) and that it is unmaintained, this PR moves over to `eslint-linter-browserify` instead.

It has been a fairly seamless transition. Had to add a `let window;` to the top of the webpacked version as it would complain about it being undefined otherwise - because we run in a WebWorker.

But I have verified the hang in #36 doesn't happen and my sniff testing of other lint rules looks good. Test in browser and CLI.