### PR TITLE
Support false value to disable rule in .nrlintrc.js file

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -62,7 +62,7 @@ function lint(flowobj, config) {
         // Get the rule implementation
         let rule = resolveRule(ruleName);
 
-        if (!rule || config.rules[ruleName] === "off") {
+        if (!rule || !config.rules[ruleName] || config.rules[ruleName] === "off") {
             // Not a rule we know about, or rule disabled ("off")
             return
         }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I forget the background of why `true` and `"off"` are used to enable and disable rules in the `.nrlintrc.js` configuration file. Because I think that `true` and `false` are natural for this case, I try to add support for the `false` value in this pull request.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.